### PR TITLE
Fix ranking candidate name and export path handling

### DIFF
--- a/backend/api_service.py
+++ b/backend/api_service.py
@@ -253,9 +253,11 @@ async def get_status(job_id: str):
 async def export_results(job_id: str, format: str = "json"):
     jrank = os.path.join(PROCESSED_DATA_FOLDER, f"{job_id}_ranked_candidates.json")
     janal = os.path.join(PROCESSED_DATA_FOLDER, f"{job_id}_analysis.json")
-    file_path = jrank if os.path.exists(jrank) else janal
-
-    if not file_path:
+    if os.path.exists(jrank):
+        file_path = jrank
+    elif os.path.exists(janal):
+        file_path = janal
+    else:
         raise HTTPException(500, "No results to export.")
 
     if format.lower() == "json":

--- a/backend/rank_candidates.py
+++ b/backend/rank_candidates.py
@@ -105,7 +105,8 @@ def _upsert_rankings(ranked_list: list, job_id: str) -> None:
                 "job_id": job_id,
                 "rank": idx,
                 "total_score": cand["analysis"]["Relative Ranking Score"],
-                "candidate_name": file_name.replace(".pdf", ""),
+                # Strip any file extension to get a clean candidate name
+                "candidate_name": os.path.splitext(file_name)[0],
                 "status": DEFAULT_STATUS,
             }
         )

--- a/backend/resumes/fdf7e4a4-7e35-4d5d-88d6-afb0dacb7ea6/res-5/test_read.py
+++ b/backend/resumes/fdf7e4a4-7e35-4d5d-88d6-afb0dacb7ea6/res-5/test_read.py
@@ -1,4 +1,0 @@
-import openai
-client = openai.OpenAI(api_key="ygsk_xS9XaDAYO4mtqllgnfBtWGdyb3FYspuBvYYsuaLXywveoqBLfyLGour_key", base_url="https://api.groq.com/openai/v1")
-res = client.models.list()
-print(res)


### PR DESCRIPTION
## Summary
- remove unused test file causing failing pytest import
- improve file selection in `/export` endpoint
- derive candidate names in ranking without relying on a specific extension

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bdc1ac9083258ac945704ea077a3